### PR TITLE
Round to nearest integer instead of down

### DIFF
--- a/app/src/main/java/com/jksalcedo/librefind/ui/dashboard/components/SovereigntyGauge.kt
+++ b/app/src/main/java/com/jksalcedo/librefind/ui/dashboard/components/SovereigntyGauge.kt
@@ -20,6 +20,7 @@ import com.jksalcedo.librefind.ui.theme.CapturedOrange
 import com.jksalcedo.librefind.ui.theme.FossGreen
 import com.jksalcedo.librefind.ui.theme.SovereignGold
 import com.jksalcedo.librefind.ui.theme.TransitionBlue
+import kotlin.math.roundToInt
 
 /**
  * Circular sovereignty gauge showing FOSS percentage
@@ -61,7 +62,7 @@ fun SovereigntyGauge(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "${score.fossPercentage.toInt()}%",
+                    text = "${score.fossPercentage.roundToInt()}%",
                     style = MaterialTheme.typography.displayMedium,
                     fontWeight = FontWeight.Bold,
                     color = getLevelColor(score.level)


### PR DESCRIPTION
Currently it always rounds down for example if you have 45 apps and 40 of them are FOSS it says 88% even so the correct value is much closer to 89% (40/45 = 8/9 = 0.88888888...)