### PR TITLE
Maybe ignored apps should get ignored in fossPercentage calculation?

### DIFF
--- a/app/src/main/java/com/jksalcedo/librefind/domain/model/SovereigntyScore.kt
+++ b/app/src/main/java/com/jksalcedo/librefind/domain/model/SovereigntyScore.kt
@@ -20,7 +20,7 @@ data class SovereigntyScore(
      * Percentage of FOSS apps (0-100)
      */
     val fossPercentage: Float
-        get() = if (totalApps > 0) (fossCount.toFloat() / totalApps) * 100 else 0f
+        get() = if (totalApps - ignoredCount > 0) (fossCount.toFloat() / (totalApps - ignoredCount)) * 100 else 0f
 
     /**
      * Sovereignty level based on percentage


### PR DESCRIPTION
I believe ignored apps shouldn't count to the fossPercentage. @rustydigits argued that this should be a setting in the app because everybody has their own opinion on this. So you can close this PR and create a setting if you like.