### PR TITLE
Set color of splash screen to dark if dark theme is active

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.LibreFind" parent="android:Theme.Material.NoActionBar" />
+</resources>


### PR DESCRIPTION
The splash screen looks always like this: 
<img width="120" height="256" alt="light-theme" src="https://github.com/user-attachments/assets/a2ba865f-a072-4487-bdc4-b7d0ff9daf8e" />

With this commit it would look like this if dark mode is enabled on device:
<img width="120" height="256" alt="dark-theme" src="https://github.com/user-attachments/assets/48fe04b2-5f91-4b61-a652-b4b8e7176387" />
