### PR TITLE
fix: restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ make alternative discovery accessible to everyone.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jksalcedo/librefind&type=date&legend=top-left&theme=dark)](https://www.star-history.com/#jksalcedo/librefind&type=date&legend=top-left&theme=dark)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jksalcedo/librefind&type=date&legend=top-left&theme=dark)](https://star-history.dera.page/#jksalcedo/librefind&type=date&legend=top-left&theme=dark)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so the chart renders correctly again.